### PR TITLE
Add customizable "Other Categories" label and fix extra divider line

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Discourse theme component that organizes sidebar categories into customizable 
 - **Use Gradient Fade**: Enable gradient background effect on section headers (50% solid color, 50% fade to transparent)
 - **Categories to Hide**: Comma-separated category slugs to hide from all views (e.g., `staff,private`)
 - **Default View**: Choose which view loads by default (custom or default)
+- **Other Categories Label**: Customize the label for ungrouped categories (default: "Other Categories")
 
 ### Section Settings (1-10)
 
@@ -63,7 +64,7 @@ Once installed and configured:
    - In default view: Toggle button appears in the default "Categories" header
 4. **Subcategories**: When enabled per section, subcategories appear indented below parent categories
 5. **Category Badges**: Small colored squares (if enabled) show each category's color
-6. **Ungrouped Categories**: Any categories not assigned to sections appear in "Other Categories"
+6. **Ungrouped Categories**: Any categories not assigned to sections appear in a separate section (label customizable via settings)
 7. **Preferences**: Your view choice and open/closed state are saved per browser
 
 ## Advanced Features

--- a/common/common.scss
+++ b/common/common.scss
@@ -302,6 +302,13 @@
     padding-top: 1em;
     border-top: 1px solid var(--primary-low);
 
+    // Remove border when ungrouped is the only section (no custom sections above)
+    &:first-child {
+      border-top: none;
+      margin-top: 0;
+      padding-top: 0;
+    }
+
     .ungrouped-categories-title {
       font-size: 0.9em;
       font-weight: 600;
@@ -336,5 +343,11 @@
         opacity: 0.9;
       }
     }
+  }
+
+  // Remove border when immediately after the header (no sections between)
+  .custom-categories-header + #ungrouped-categories-sidebar {
+    border-top: none;
+    margin-top: 0;
   }
 }

--- a/javascripts/discourse/api-initializers/sidebar-organizer.js
+++ b/javascripts/discourse/api-initializers/sidebar-organizer.js
@@ -233,7 +233,7 @@ export default apiInitializer("1.8.0", (api) => {
 
       const ungroupedTitle = document.createElement("div");
       ungroupedTitle.className = "ungrouped-categories-title";
-      ungroupedTitle.textContent = "Other Categories";
+      ungroupedTitle.textContent = settings.other_categories_label || "Other Categories";
       ungroupedSection.appendChild(ungroupedTitle);
 
       ungroupedCategories.forEach(category => {

--- a/settings.yml
+++ b/settings.yml
@@ -36,7 +36,7 @@ default_view:
 other_categories_label:
   default: "Other Categories"
   type: string
-  description: "Label for the section containing categories not assigned to any group"
+  description: "Label for the section containing categories not assigned to any other section"
 
 # Section 1
 section_1_enabled:

--- a/settings.yml
+++ b/settings.yml
@@ -33,6 +33,11 @@ default_view:
     - default
   description: "Which view to show by default (custom sections or default categories list)"
 
+other_categories_label:
+  default: "Other Categories"
+  type: string
+  description: "Label for the section containing categories not assigned to any group"
+
 # Section 1
 section_1_enabled:
   default: true


### PR DESCRIPTION
## Summary
- Add customizable label for "Other Categories" section via new `other_categories_label` setting (defaults to "Other Categories")
- Fix extra divider line appearing when no custom sections are enabled and only ungrouped categories exist

## Changes

**New Feature: Customizable "Other Categories" Label**
- Added `other_categories_label` setting in `settings.yml` allowing admins to rename the ungrouped categories section (e.g., "Uncategorized", "More Categories", "Everything Else")
- Updated `sidebar-organizer.js` to use the setting with fallback to default

<img width="1200" height="350" alt="CleanShot 2026-01-31 at 10 31 04@2x" src="https://github.com/user-attachments/assets/173e0111-c1bf-499a-b53a-469549d7cf6f" />

---

**Bug Fix: Extra Divider Line**
- Fixed CSS issue where a border-top appeared unnecessarily when no custom sections were configured
- Added `:first-child` and adjacent sibling selectors to hide the divider when ungrouped categories is the only/first section

<img width="508" height="732" alt="CleanShot 2026-01-31 at 10 17 51@2x" src="https://github.com/user-attachments/assets/723b3bf6-9fe8-43ba-818a-75c24fe013be" />



## Test plan
- [ ] Enable the component with no sections configured - verify no extra divider line above "Other Categories"
- [ ] Change `other_categories_label` setting to a custom value - verify the label updates
- [ ] Leave the setting empty - verify it falls back to "Other Categories"
- [ ] Enable some sections alongside ungrouped categories - verify the divider appears correctly between them